### PR TITLE
feat(api): allow renew with explicit tariff_id from same group

### DIFF
--- a/api/v2/routes/keys/user/renew.py
+++ b/api/v2/routes/keys/user/renew.py
@@ -49,7 +49,24 @@ async def user_key_renew(
         raise HTTPException(status_code=404, detail="Подписка не найдена")
     if bool(getattr(db_key, "is_frozen", False)):
         raise HTTPException(status_code=400, detail="Продление для замороженной подписки недоступно")
-    tariff_id = getattr(db_key, "tariff_id", None)
+    db_tariff_id = getattr(db_key, "tariff_id", None)
+    # Клиент может явно указать тариф (например, чтобы продлить с другим
+    # сроком). Тогда валидируем, что он активен и относится к той же
+    # group_code/subgroup_title, что и текущий тариф ключа — ровно так же,
+    # как процессит выбор тарифа Telegram-handler `process_callback_renew_plan`.
+    if body.tariff_id is not None and int(body.tariff_id) != int(db_tariff_id or 0):
+        requested = await get_tariff_by_id(session, int(body.tariff_id))
+        if not requested or not requested.get("is_active", True):
+            raise HTTPException(status_code=404, detail="Тариф не найден")
+        current = await get_tariff_by_id(session, int(db_tariff_id or 0)) if db_tariff_id else None
+        if current and (
+            (requested.get("group_code") or "") != (current.get("group_code") or "")
+            or (requested.get("subgroup_title") or "") != (current.get("subgroup_title") or "")
+        ):
+            raise HTTPException(status_code=400, detail="Тариф недоступен для этой подписки")
+        tariff_id = int(body.tariff_id)
+    else:
+        tariff_id = db_tariff_id
     if not tariff_id:
         raise HTTPException(status_code=400, detail="Для подписки не назначен тариф")
     key_email = str(getattr(db_key, "email", "") or "")

--- a/api/v2/schemas/web_public.py
+++ b/api/v2/schemas/web_public.py
@@ -86,6 +86,7 @@ class AccountKeyRenewRequest(BaseModel):
     success_url: str | None = None
     failure_url: str | None = None
     coupon_code: str | None = None
+    tariff_id: int | None = None
 
 
 class AccountKeyRenewResponse(AccountKeyActionResponse):


### PR DESCRIPTION
## Что и зачем

Сейчас `POST /api/v2/keys/{client_id}/renew` всегда продлевает по тарифу, который уже привязан к ключу (`db_key.tariff_id`). Через HTTP API нет способа продлить с другим тарифом — например, переключиться с 30-дневного на 90/180/360-дневный. Через Telegram-бота это работает (`process_callback_renew_plan`: пользователь жмёт нужный план, ключу проставляется новый `tariff_id`, и идёт продление).

В результате веб-клиенту/мини-аппу приходится либо вообще убирать выбор срока продления, либо использовать обходные пути (admin-патч `Key.tariff_id` + сразу renew), что плохо для UX и race-prone.

Этот PR добавляет возможность передать опциональный `tariff_id` в теле запроса. Если он указан — валидируется, что тариф активен и относится к той же `group_code` / `subgroup_title`, что и текущий тариф ключа (точно как в Telegram-handler `process_callback_renew_plan`). Дальше существующий `calculate_renewal_pricing` / `execute_renewal` сам корректно отрабатывает: новый `tariff_id` пишется в `Key.tariff_id` через уже существующий `update_key_renewal_snapshot`.

## Изменения

- `api/v2/schemas/web_public.py`: в `AccountKeyRenewRequest` добавлено опциональное поле `tariff_id: int | None = None`.
- `api/v2/routes/keys/user/renew.py`: если в body указан `tariff_id`, отличный от текущего, проверяется наличие/активность тарифа и совпадение группы/подгруппы; иначе используется старая логика (`db_key.tariff_id`).

## Совместимость

- Поле опциональное, значение по умолчанию `None`. Все существующие клиенты, которые не передают `tariff_id`, получают **прежнее** поведение — нулевые регрессии.
- Валидация принципиально та же, что в `process_callback_renew_plan`: запрещено перепрыгивать в другую группу/подгруппу.
- `preview=true` работает с новым полем без дополнительных изменений (`calculate_renewal_pricing` уже принимает `tariff_id` параметром).

## Тестовый сценарий

1. Клиент: `POST /api/keys/{client_id}/renew?preview=true` с `{tariff_id: <other_tariff_in_same_group>}` → ответ содержит `final_price_rub` нового тарифа и корректный `payment_required`.
2. Тот же запрос без `preview` → подписка продлевается на длительность нового тарифа, `Key.tariff_id` переключается, баланс списывается на `final_price_rub`.
3. Запрос с `tariff_id` из другой `group_code`/`subgroup_title` → `400 Тариф недоступен для этой подписки`.
4. Запрос с несуществующим/неактивным `tariff_id` → `404 Тариф не найден`.
5. Запрос без `tariff_id` (или равный текущему) → поведение не меняется.